### PR TITLE
Eliminate `const`-related warnings in c extensions

### DIFF
--- a/bdb/bdb_stubs.c
+++ b/bdb/bdb_stubs.c
@@ -62,7 +62,9 @@ static void dbt_from_string(DBT *dbt, value v) {
   // indicate to bdb that it shouldn't modify this buffer
   dbt->data = (void *)String_val(v);
   dbt->size = string_length(v);
+#ifdef DB_DBT_READONLY
   dbt->flags = DB_DBT_READONLY;
+#endif
 }
 
 #if OCAML_VERSION < 40600

--- a/bdb/bdb_stubs.c
+++ b/bdb/bdb_stubs.c
@@ -662,8 +662,7 @@ value caml_db_get(value db, value txn_opt, value vkey, value vflags) {
 
   // FIX: this currently uses an extra, unnecessary copy in order to simplify
   // memory management.
-  rval = alloc_string(data.size);
-  memcpy (String_val(rval), data.data, data.size);
+  rval = caml_alloc_initialized_string(data.size, data.data);
   CAMLreturn (rval);
 }
 
@@ -957,8 +956,7 @@ value caml_cursor_init(value cursor, value vkey, value vflags) {
     raise_db(db_strerror(err));
   }
 
-  rval = alloc_string(data.size);
-  memcpy (String_val(rval), data.data, data.size);
+  rval = caml_alloc_initialized_string(data.size, data.data);
   CAMLreturn (rval);
 }
 
@@ -985,14 +983,10 @@ value caml_cursor_init_range(value cursor, value vkey, value vflags) {
     raise_db(db_strerror(err));
   }
 
-  rdata = alloc_string(data.size);
-  memcpy (String_val(rdata), data.data, data.size);
+  rdata = caml_alloc_initialized_string(data.size, data.data);
+  rkey = caml_alloc_initialized_string(key.size, key.data);
 
-  rkey = alloc_string(key.size);
-  memcpy (String_val(rkey), key.data, key.size);
-
-  rpair = alloc(2,0);
-
+  rpair = caml_alloc_tuple(2);
   Store_field(rpair,0,rkey);
   Store_field(rpair,1,rdata);
 
@@ -1051,11 +1045,9 @@ value caml_cursor_get(value cursor, value vtype, value vflags) {
     raise_db(db_strerror(err));
   }
 
-  rkey = alloc_string(key.size);
-  memcpy (String_val(rkey), key.data, key.size);
-  rdata = alloc_string(data.size);
-  memcpy (String_val(rdata), data.data, data.size);
-  rpair = alloc(2,0);
+  rkey = caml_alloc_initialized_string(key.size, key.data);
+  rdata = caml_alloc_initialized_string(data.size, data.data);
+  rpair = caml_alloc_tuple(2);
   Store_field(rpair,0,rkey);
   Store_field(rpair,1,rdata);
   CAMLreturn (rpair);
@@ -1081,8 +1073,7 @@ value caml_cursor_get_keyonly(value cursor, value vtype, value vflags) {
     raise_db(db_strerror(err));
   }
 
-  rkey = alloc_string(key.size);
-  memcpy (String_val(rkey), key.data, key.size);
+  rkey = caml_alloc_initialized_string(key.size, key.data);
   CAMLreturn (rkey);
 }
 

--- a/bdb/bdb_stubs.c
+++ b/bdb/bdb_stubs.c
@@ -29,6 +29,7 @@
 #include <caml/fail.h>
 #include <caml/memory.h>
 #include <caml/callback.h>
+#include <caml/version.h>
 
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -63,6 +64,17 @@ static void dbt_from_string(DBT *dbt, value v) {
   dbt->size = string_length(v);
   dbt->flags = DB_DBT_READONLY;
 }
+
+#if OCAML_VERSION < 40600
+/* Provide our own version of the caml_alloc_initialized_string()
+   convenience function when compiling for older versions of ocaml */
+static value caml_alloc_initialized_string(size_t len, const char *p)
+{
+  value result = caml_alloc_string(len);
+  memcpy((char *)String_val(result),p,len);
+  return result;
+}
+#endif
 
 #define test_cursor_closed(cursor) \
   if (UW_cursor_closed(cursor)) \

--- a/bdb/bdb_stubs.c
+++ b/bdb/bdb_stubs.c
@@ -181,9 +181,9 @@ static struct custom_operations txn_custom = {
 /************ Exception buckets *****************************/
 /************************************************************/
 
-static value *caml_db_exn = NULL;
-static value *caml_key_exists_exn = NULL;
-static value *caml_db_run_recovery_exn = NULL;
+static const value *caml_db_exn = NULL;
+static const value *caml_key_exists_exn = NULL;
+static const value *caml_db_run_recovery_exn = NULL;
 
 value caml_db_init(value v){
   CAMLparam1(v);
@@ -313,7 +313,7 @@ value caml_dbenv_open(value dbenv, value vdirectory,
                       value vflags, value vmode){
   CAMLparam4(dbenv,vdirectory,vflags,vmode);
   int err;
-  char *directory = String_val(vdirectory);
+  const char *directory = String_val(vdirectory);
   int flags = convert_flag_list(vflags,dbenv_open_flags);
 
   test_dbenv_closed(dbenv);
@@ -531,7 +531,7 @@ value caml_db_open(value db, value vfname,
                    value vmode){
   CAMLparam5(db, vfname, vdbtype, vflags, vmode);
   int err;
-  char *fname = String_val(vfname);
+  const char *fname = String_val(vfname);
   int flags = convert_flag_list(vflags,db_open_flags);
   int dbtype = Flag_val(vdbtype,db_types);
 

--- a/crc.c
+++ b/crc.c
@@ -32,7 +32,7 @@
 #define CRC24_POLY 0x1864cfbL
 
 typedef long crc24;
-crc24 crc_octets(unsigned char *octets, size_t len) {
+crc24 crc_octets(unsigned const char *octets, size_t len) {
   crc24 crc = CRC24_INIT;
   int i;
 
@@ -50,7 +50,7 @@ crc24 crc_octets(unsigned char *octets, size_t len) {
 value caml_crc_octets(value data) {
   CAMLparam1(data);
   CAMLlocal1(rval);
-  unsigned char *octets = String_val(data);
+  unsigned const char *octets = String_val(data);
   size_t len = string_length(data);
   long crc = crc_octets(octets,len);
 


### PR DESCRIPTION
This eliminates the compile-time warnings related to implicitly losing the `const` qualification on pointers, mostly in the bdb interface code. The three patches in this pull request are each self-contained and address one kind of problem:

* variables that are constant, but aren't declared `const`
* creating an ocaml string from a bdb DBT: here, I modernized slightly to use `caml_alloc_initialized_string()` which does the memcpy internally
* creating a bdb DBT from an ocaml string: factored this out into a small helper function
