### PR TITLE
tail recursive key parsing

### DIFF
--- a/keyMerge.ml
+++ b/keyMerge.ml
@@ -87,15 +87,21 @@ let packets_equal p1 p2 = p1 = p2
 (*******************************************************************)
 (** Code for flattening out the above structure back to the original key *)
 
-let rec flatten_sigpair_list list = match list with
-    [] -> []
-  |  (pack,sigs)::tl -> pack :: (sigs @ flatten_sigpair_list tl)
+let rec flatten_sigpair_list list =
+  match list with
+  | [] -> []
+  | (pack,sigs)::tl -> pack :: (List.rev_append sigs (flatten_sigpair_list tl)) (* order of sigs doesn't matter *)
+
+(* stack proportional to [List.length l] which is constant in our case *)
+let rec list_concat l =
+  match l with
+  | [] -> []
+  | h::tl -> List.rev_append (List.rev h) (list_concat tl)
 
 let flatten key =
-  key.key :: List.concat [ key.selfsigs;
+  key.key :: list_concat [ key.selfsigs;
                            flatten_sigpair_list key.uids;
                            flatten_sigpair_list key.subkeys ]
-
 
 (************************************************************)
 

--- a/keyMerge.ml
+++ b/keyMerge.ml
@@ -99,12 +99,21 @@ let flatten key =
 
 (************************************************************)
 
+let nr_packets l = List.fold_left ~f:(fun acc (_,l) -> acc + List.length l) ~init:0 l
+
 let print_pkey key =
-  printf "%d selfsigs, %d uids, %d subkeys\n"
+  let uid =
+    match List.filter ~f:(fun (p,_) -> p.packet_type = User_ID_Packet) key.uids with
+    | [] -> ""
+    | (h,_)::_ -> h.packet_body
+  in
+  printf "%S : %d selfsigs, %d uids (%d packets), %d subkeys (%d packets)\n"
+    uid
     (List.length key.selfsigs)
     (List.length key.uids)
+    (nr_packets key.uids)
     (List.length key.subkeys)
-
+    (nr_packets key.subkeys)
 
 (*******************************************************************)
 


### PR DESCRIPTION
Continuing the work in #78 
Now it is possible to import the following key (prz@acm.org) with stack lowered to 1MB (`ulimit -s 1024`) :
```
1 selfsigs, 5 uids (101025 packets), 1 subkeys (273 packets)
```

TODO:
* extract the anomaly key and make a test case
* measure speed